### PR TITLE
cleanup(doc): removal of embedabble-build-status badge(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,67 +4,67 @@ embedabble-build-status badges examples for https://github.com/jenkins-infra/hel
 
 ```
 A) jenkins-infra-test-plugin
-[![Jenkins](https://ci.jenkins.io/job/plugins/job/jenkins-infra-test-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/plugins/job/jenkins-infra-test-plugin/job/master/)
+[**jenkins-infra-test-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/plugins/job/jenkins-infra-test-plugin/job/master)
 
 B) jenkins-infra-test-plugin
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/jenkins-infra-test-plugin/master)](https://ci.jenkins.io/buildStatus/icon?job=Plugins/jenkins-infra-test-plugin/master)
+[**jenkins-infra-test-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/jenkins-infra-test-plugin/job/master)
 
 C) simple-theme-plugin
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fsimple-theme-plugin%2Fmain)](https://ci.jenkins.io/job/Plugins/job/simple-theme-plugin/job/main/)
+[**simple-theme-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/simple-theme-plugin/job/main)
 
 D) test-results-aggregator-plugin
-image:https://ci.jenkins.io/buildStatus/icon?job=Plugins/test-results-aggregator-plugin/master[https://github.com/jenkinsci/role-strategy-plugin/releases/latest]
+[**test-results-aggregator-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/test-results-aggregator-plugin/job/master)
 
 E) graphql-server-plugin
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?style=plastic&job=Plugins%2Fgraphql-server-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/graphql-server-plugin/job/master/)
+[**graphql-server-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/graphql-server-plugin/job/master)
 
 F) muuri-api-plugin
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?subject=Jenkins%20CI&job=Plugins%2Fmuuri-api-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/muuri-api-plugin/job/master/)
+[**muuri-api-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/muuri-api-plugin/job/master)
 
 G) acceptance-test-harness
-[![Jenkins](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/badge/icon)](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/)
+[**acceptance-test-harness** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master)
 
 H) [scm-filter-branch-pr-plugin](https://github.com/jenkinsci/scm-filter-branch-pr-plugin/blob/ac8eeefa235a55fbdbddb19bb086e50e06081d4b/DEVELOPER_README.md?plain=1#L59)
-[build-icon]: https://ci.jenkins.io/buildStatus/icon?job=Plugins/scm-filter-branch-pr-plugin/master
+[**scm-filter-branch-pr-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/scm-filter-branch-pr-plugin/job/master)
 
 I) [log-command-plugin](https://github.com/jenkinsci/log-command-plugin/blame/e8e78fa1f8de2efc1ebd7613682214b8dcb1c1bf/README.adoc#L14)
-image:https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Flog-command-plugin%2Fmaster[]
+[**log-command-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/log-command-plugin/job/master)
 
 J) [git-parameter-plugin](https://github.com/Mojang/git-parameter-plugin/blame/a466390e7f27fb205bec874cec5dfed946a13d57/README.textile#L14)
-* The Jenkins-CI of this plugin can be seen at "DEV@cloud":https://ci.jenkins.io/job/Plugins/job/git-parameter-plugin/. The status is <a href='https://ci.jenkins.io/job/Plugins/job/git-parameter-plugin/'><img src='https://ci.jenkins.io/buildStatus/icon?job=Plugins/git-parameter-plugin/master'></a>
+[**git-parameter-plugin/master'><** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/git-parameter-plugin/master)
 
 ```
 <details><summary>Preview:</summary>
 
 A) jenkins-infra-test-plugin
-[![Jenkins](https://ci.jenkins.io/job/plugins/job/jenkins-infra-test-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/plugins/job/jenkins-infra-test-plugin/job/master/)
+[**jenkins-infra-test-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/plugins/job/jenkins-infra-test-plugin/job/master)
 
 B) jenkins-infra-test-plugin
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/jenkins-infra-test-plugin/master)](https://ci.jenkins.io/buildStatus/icon?job=Plugins/jenkins-infra-test-plugin/master)
+[**jenkins-infra-test-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/jenkins-infra-test-plugin/job/master)
 
 C) simple-theme-plugin
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fsimple-theme-plugin%2Fmain)](https://ci.jenkins.io/job/Plugins/job/simple-theme-plugin/job/main/)
+[**simple-theme-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/simple-theme-plugin/job/main)
 
 D) test-results-aggregator-plugin
-image:https://ci.jenkins.io/buildStatus/icon?job=Plugins/test-results-aggregator-plugin/master[https://github.com/jenkinsci/role-strategy-plugin/releases/latest]
+[**test-results-aggregator-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/test-results-aggregator-plugin/job/master)
 
 E) graphql-server-plugin
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?style=plastic&job=Plugins%2Fgraphql-server-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/graphql-server-plugin/job/master/)
+[**graphql-server-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/graphql-server-plugin/job/master)
 
 F) muuri-api-plugin
-[![Build Status](https://ci.jenkins.io/buildStatus/icon?subject=Jenkins%20CI&job=Plugins%2Fmuuri-api-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/muuri-api-plugin/job/master/)
+[**muuri-api-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/muuri-api-plugin/job/master)
 
 G) acceptance-test-harness
-[![Jenkins](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/badge/icon)](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master/)
+[**acceptance-test-harness** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Core/job/acceptance-test-harness/job/master)
 
 H) [scm-filter-branch-pr-plugin](https://github.com/jenkinsci/scm-filter-branch-pr-plugin/blob/ac8eeefa235a55fbdbddb19bb086e50e06081d4b/DEVELOPER_README.md?plain=1#L59)
-[build-icon]: https://ci.jenkins.io/buildStatus/icon?job=Plugins/scm-filter-branch-pr-plugin/master
+[**scm-filter-branch-pr-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/scm-filter-branch-pr-plugin/job/master)
 
 I) [log-command-plugin](https://github.com/jenkinsci/log-command-plugin/blame/e8e78fa1f8de2efc1ebd7613682214b8dcb1c1bf/README.adoc#L14)
-image:https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Flog-command-plugin%2Fmaster[]
+[**log-command-plugin** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/log-command-plugin/job/master)
 
 J) [git-parameter-plugin](https://github.com/Mojang/git-parameter-plugin/blame/a466390e7f27fb205bec874cec5dfed946a13d57/README.textile#L14)
-* The Jenkins-CI of this plugin can be seen at "DEV@cloud":https://ci.jenkins.io/job/Plugins/job/git-parameter-plugin/. The status is <a href='https://ci.jenkins.io/job/Plugins/job/git-parameter-plugin/'><img src='https://ci.jenkins.io/buildStatus/icon?job=Plugins/git-parameter-plugin/master'></a>
+[**git-parameter-plugin/master'><** builds status on ci.jenkins.io](https://ci.jenkins.io/job/Plugins/job/git-parameter-plugin/master)
 
 </details>
 


### PR DESCRIPTION
As explained in [this announcement](https://github.com/jenkinsci/embeddable-build-status-plugin/issues/82), the  plugin will be removed from the ci.jenkins.io public instance, thus the badge(s) in this repository won't work anymore. <br />This pull request made in bulk for the Jenkins Infrastructure team aims at replacing these badges by a link to the builds status on ci.jenkins.io