### PR TITLE
Testing ACP with deprecated `artifactCachingProxyEnabled` parameter name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,5 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
+@Library('pipeline-library@pull/576/head') _
 buildPlugin(useContainerAgent: true, platforms: ['linux', 'windows'], artifactCachingProxyEnabled: true, jdkVersions: ['8','11','17'])


### PR DESCRIPTION
Testing if this deprecated parameter name is still taken in account.

Ref: https://github.com/jenkins-infra/pipeline-library/pull/576