### PR TITLE
test: try using default ACP opt-in with the pipeline-library PR 577

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('pipeline-library@pull/577/head') _
+
 /*
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/


### PR DESCRIPTION
This PR is an ephemeral test to "end to end" test the pipeline library change https://github.com/jenkins-infra/pipeline-library/pull/577 .

It should be closed once the validation is finished.

The goal is to be sure that the Artifact Caching Proxy is enabled by default once the PR 577 is merged.
