### PR TITLE
Testing jenkins-infra/pipeline-library#705

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('pipeline-library@pull/705/head') _
+@Library('pipeline-library@pull/705/head') _ // TODO remove after #98 merged & released
 buildPlugin(
   useContainerAgent: true,
   configurations: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+@Library('pipeline-library@pull/705/head') _
 buildPlugin(
   useContainerAgent: true,
   configurations: [


### PR DESCRIPTION
Checking https://github.com/jenkins-infra/pipeline-library/pull/705. Need to verify

- [x] that the head of this PR is deployed via `ci.jenkins.io` to `incrementals`
- [ ] that after it is merged, the resulting `master` commit succeeds on `ci.jenkins.io` but does not deploy
- [ ] that JEP-229 deployment to `releases` via GHA succeeds after that

at which point this can be reverted to clean up.