### PR TITLE
Require Jenkins 2.479.1 or newer

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ By opening a pull request on this repos with the following content, you'll be ab
   buildPlugin(
     useContainerAgent: true,
     configurations: [
-      [platform: 'linux', jdk: 17],
-      [platform: 'windows', jdk: 11],
+      [platform: 'linux', jdk: 21],
+      [platform: 'windows', jdk: 17],
   ])
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.2</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
     <packaging>hpi</packaging>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <name>Jenkins infrastructure test</name>
@@ -24,8 +25,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>3613.v584fca_12cf5c</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Require Jenkins 2.479.1 or newer

Java 11 is no longer supported by Jenkins core.  Updates this test plugin to require Jenkins 2.479.1 or newer and to use Java 17 and Java 21 for build and in the documentation.

Includes changes from:

* https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/135

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
