### PR TITLE
Pretest lib PR-991: declared use of Incrementals

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
+@Library('pipeline-library@pull/991/head') _
 buildPlugin(
   useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 25],
-    [platform: 'windows', jdk: 25],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
-@Library('pipeline-library@pull/991/head') _
 buildPlugin(
   useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 25],
 ])

--- a/consume-incrementals
+++ b/consume-incrementals
@@ -1,0 +1,1 @@
+https://github.com/jenkinsci/bom/pull/6354

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <packaging>hpi</packaging>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.baseline>2.516</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <name>Jenkins infrastructure test</name>
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5054.v620b_5d2b_d5e6</version>
+                <version>6044.ve00c1d1a_3a_a_1</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -60,4 +60,30 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>run-script</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>sh</executable>
+                            <arguments>
+                                <argument>-c</argument>
+                                <argument>fgrep -i mirror "$MAVEN_SETTINGS" || :</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
https://github.com/jenkins-infra/pipeline-library/pull/991

- :heavy_check_mark: build is [unstable](https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/211/checks?check_run_id=63591247616)
- :heavy_check_mark: publishes Incrementals anyway (build status is checked before this)